### PR TITLE
Fixed remove_spaces function

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,9 +22,7 @@ SRCS =	./srcs/init.c \
 		./srcs/parsing/term_attributes.c \
 		./srcs/exec/exec.c \
 		./srcs/utils.c \
-		./srcs/parsing/substitutions.c \
 		./srcs/parsing/redirections.c \
-				
 
 #colours ------------------------------------------
 B_BLUE='\033[1;34m'

--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,8 @@ SRCS =	./srcs/init.c \
 		./srcs/parsing/term_attributes.c \
 		./srcs/exec/exec.c \
 		./srcs/utils.c \
+		./srcs/parsing/substitutions.c \
+		./srcs/parsing/redirections.c \
 				
 
 #colours ------------------------------------------

--- a/includes/minishell.h
+++ b/includes/minishell.h
@@ -41,10 +41,10 @@
 
 typedef struct s_command
 {
+	char				**cmd;
 	int					infile;
 	int					outfile;
-	char				*cmd;
-	char				*args;
+	int					builtin_flag;
 	struct s_command	*next;
 }					t_command;
 

--- a/srcs/parsing/commands/command_list.c
+++ b/srcs/parsing/commands/command_list.c
@@ -21,7 +21,7 @@ t_command	*add_command(char *command, int infile, int outfile)
 	new = create_command();
 	if (!new)
 		return (NULL);
-	new->cmd = ft_strdup(command);
+	// new->cmd = ft_strdup(command);
 	new->infile = infile;
 	new->outfile = outfile;
 	if (use_data()->cmd == NULL)

--- a/srcs/parsing/redirections.c
+++ b/srcs/parsing/redirections.c
@@ -1,0 +1,47 @@
+
+#include "../../includes/minishell.h"
+#include "../../includes/parsing.h"
+
+// >
+// int	token_redirout(t_token *token, t_command *cmd)
+// {
+// 	int	fd;
+
+// 	if (access(token, F_OK) == 0 
+// 		|| access(ft_tolower(token), F_OK == 0))
+// 	{
+// 		if (access (token, W_OK) == 0 || access (ft_tolower(token), W_OK) == 0)
+// 			fd = open(token, O_TRUNC | O_WRONLY);
+// 		else
+// 			return (-1);
+// 	}
+// 	else
+// 		fd = open(token, O_CREAT | O_TRUNC | O_WRONLY, 0644);
+// 	if (cmd->outfile != STDOUT_FILENO)
+// 		close(cmd->outfile);
+// 	cmd->outfile = fd;
+// 	return (0);
+// }
+
+// //<
+// int	token_redirin(t_token *token, t_command *cmd)
+// {
+// 	int	fd;
+
+// 	if (access(token, O_RDONLY) == 0 || access(ft_tolower(token), O_RDONLY == 0))
+	
+// 	if (cmd->infile != STDOUT_FILENO)
+// 		close(cmd->infile);
+// 	cmd->infile = fd;
+// }
+
+// int	token_pipe(t_token *token)
+// {
+
+// }
+
+// //>>
+// int	token_redirappend(t_token *token)
+// {
+
+// }

--- a/srcs/parsing/tokens/line_parsing.c
+++ b/srcs/parsing/tokens/line_parsing.c
@@ -21,31 +21,71 @@ int	parse_quotes(char *str)
 	return (0);
 }
 
+//Finds the lengh of str without whitespaces before, after or consecutive
+int	find_lenght(char *str, int end)
+{
+	int	i;
+	int	len;
+
+	i = 0;
+	len = 0;
+	while (i < end && ft_iswhitespace(str[i]))
+		i++;
+	while (i < end)
+	{
+		while (i < end && (!ft_iswhitespace(str[i])
+				|| double_quoted(str, i) || single_quoted(str, i)))
+		{
+			i++;
+			len++;
+		}
+		if (i < end)
+			len++;
+		while (ft_iswhitespace(str[i]))
+			i++;
+	}
+	return (len);
+}
+
+char	*skip_consecutivews(int i, int end, char *str)
+{
+	int		i_new;
+	char	*new_str;
+
+	new_str = ft_calloc(find_lenght(str, end), sizeof(char));
+	i_new = 0;
+	while (i < end)
+	{
+		while (!ft_iswhitespace(str[i]) 
+			|| double_quoted(str, i) || single_quoted(str, i))
+			new_str[i_new++] = str[i++];
+		if (i < end)
+			new_str[i_new++] = ' ';
+		while (ft_iswhitespace(str[i])  && !double_quoted(str, i) && !single_quoted(str, i))
+			i++;
+	}
+	return (new_str);
+}
+
+/*removes the unnecessary spaces from readline's return,
+frees use_data()->line and saves the result in use_data()->line_cpy.*/
 int	remove_spaces(char *str)
 {
-	char	*new_str;
 	int		i;
-	int		str_len;
+	int		end;
 
-	if (!str || !str[0])
-		return (free (str), ERROR);
-	i = -1;
-	str_len = 0;
-	while (str[++i])
-		if (!ft_iswhitespace(str[i]) || double_quoted(str, i) 
-			|| single_quoted(str, i)
-			|| (i != 0 && !ft_iswhitespace(str[i - 1])))
-			str_len++;
-	new_str = ft_calloc(str_len + 1, sizeof(char));
-	if (!new_str)
-		return (free (str), ERROR);
-	i = -1;
-	str_len = 0;
-	while (str[++i])
-		if (!ft_iswhitespace(str[i]) || double_quoted(str, i) 
-			|| single_quoted(str, i)
-			|| (i != 0 && !ft_iswhitespace(str[i - 1])))
-			new_str[str_len++] = str[i];
-	use_data()->line_cpy = new_str;
+	i = 0;
+	while (str[i] && ft_iswhitespace(str[i]) && !double_quoted(str, i) && !single_quoted(str, i))
+		i++;
+	end = ft_strlen(str) - 1;
+	while (ft_iswhitespace(str[end]) && !double_quoted(str, end) && !single_quoted(str, end))
+		end--;
+	if (end != i)
+		end++;
+	if (end == i)
+		use_data()->line_cpy = ft_substr(str, i, 1);
+	else
+		use_data()->line_cpy = skip_consecutivews(i, end, str);
+	free (str);
 	return (EXIT_SUCCESS);
 }

--- a/srcs/parsing/tokens/substitutions.c
+++ b/srcs/parsing/tokens/substitutions.c
@@ -72,23 +72,24 @@ int	count_nbblocks(char *line)
 	int	flag_var;
 
 	i = -1;
-	if (line[0] == '$')
-		nb_blocks = 0;
-	else
-		nb_blocks = 1;
 	flag_var = 0;
+	nb_blocks = 1;
 	while (line[++i])
 	{
 		if (line[i] == '$' && !single_quoted(line, i) && line[i + 1])
 		{
-			nb_blocks++;
+			if (i != 0)
+				nb_blocks++;
 			flag_var = 1;
 			i++;
 		}
 		if (flag_var == 1 && is_delimiter(line[i]))
 		{
-			nb_blocks++;
-			flag_var = 0;
+			if (line[i] != '?' || (line[i + 1] && line[i + 1] != '$'))
+			{
+				flag_var = 0;
+				nb_blocks++;
+			}
 		}
 	}
 	return (nb_blocks);

--- a/tools&notes/elodie_journal.txt
+++ b/tools&notes/elodie_journal.txt
@@ -1,38 +1,29 @@
 ----Most Recent----
 
 Doing :
-1 : when a redirection token is found, handle it and delete (delete token function, initiate cmd struct, )
-all letters to lower case for command/builtin (+ take everything before pipe)
-How to identify builtins ? (with first array of each command tab)
+test syntax parsing
+test substitution
+Functions for redirection tokens
 
 To do next :
+How to identify builtins ? (with first array of each command tab)
+Tester les str vides (1ère chose à faire après remove_spaces/au début de remove_spaces)
+How to merge only one file
+Study printf/gnl
 token handling functions(struc management) (add token, delete and free token)
 command handling functions(struct management) (add cmd, delete and free cmd)
 build command function (take all tokens and place them in a tab)
 action functions (if Infile redirection/outfile redirection/append redirection/pipe/end of line)
-
-Test how th git works
 Exit and clean functions
 Initiation struct et free
 
 Done :
-add is_builtin flag to struct
-1 : fixing substitution Function (test everything + write down tests)
-Added int exstat in struct (to be handled at execution)
-fixing substitution Function (Fixing variables beside one another ($USER$USER)), 
-	(add redirections as delimiters), (Handle correctly non-existing variable), (Make it so it changes use_data()->line_cpy)
-	(handle variables substituing other variables), (Handle $?)
-Created elodie-beta branch to safely work on do_substitutions
-Fixing git situation
-Remove whitespaces before and after str function
-Token_parsing function
-Create a line with only the necessary whitespaces, before tokenisation
-Verify if all quotes are closed (before tokenisation)
+fixing remove_spaces
+
 
 To discuss :
-Is "previous" in token struct useful ?
-data->quote_flag : Useful ?
-data->error_flag : Defaults to 0 ? (For init) + Check Init !
+all to lower case (cmds and files) -> check bash
+remove_spaces assume que la ligne à traiter n'est pas null et contient au moins un charactère valide (str[i])
 
 
 

--- a/tools&notes/elodie_journal.txt
+++ b/tools&notes/elodie_journal.txt
@@ -1,14 +1,23 @@
 ----Most Recent----
 
 Doing :
-1 : fixing substitution Function (test everything + write down tests)
+1 : when a redirection token is found, handle it and delete (delete token function, initiate cmd struct, )
+all letters to lower case for command/builtin (+ take everything before pipe)
+How to identify builtins ? (with first array of each command tab)
 
 To do next :
+token handling functions(struc management) (add token, delete and free token)
+command handling functions(struct management) (add cmd, delete and free cmd)
+build command function (take all tokens and place them in a tab)
+action functions (if Infile redirection/outfile redirection/append redirection/pipe/end of line)
+
 Test how th git works
 Exit and clean functions
 Initiation struct et free
 
 Done :
+add is_builtin flag to struct
+1 : fixing substitution Function (test everything + write down tests)
 Added int exstat in struct (to be handled at execution)
 fixing substitution Function (Fixing variables beside one another ($USER$USER)), 
 	(add redirections as delimiters), (Handle correctly non-existing variable), (Make it so it changes use_data()->line_cpy)
@@ -21,8 +30,7 @@ Create a line with only the necessary whitespaces, before tokenisation
 Verify if all quotes are closed (before tokenisation)
 
 To discuss :
-Added int exstat in struct (to be handled at execution)
-Git (malord)
+Is "previous" in token struct useful ?
 data->quote_flag : Useful ?
 data->error_flag : Defaults to 0 ? (For init) + Check Init !
 

--- a/tools&notes/tests_2.txt
+++ b/tools&notes/tests_2.txt
@@ -12,6 +12,8 @@ $? bash :
 $? minishell :
 notes :		empty quotes count as arguments and are handled by execve
 
+--
+
 test bash :		cat 2.c | wc | v
 			>zsh: command not found: v
 			cat 2.c | wc | v | echo $?
@@ -23,8 +25,54 @@ test bash :		cat 2.c | wc | v
 minishell :
 notes :		$? is not a substitution for the last command's exit status, but for the last pipeline.
 
+--
+
 tests bash :	export TEST1="'"Hi"'"
 				export TEST$TEST1=hi
 				>`TEST'Hi'=hi': not a valid identifier
 minishell :
 notes : ', ", $ and redirections cannot be used in environment variable names.
+
+--	SUBSTITUTIONS --
+
+test : echo $?
+bash :
+minishell :
+notes :
+
+test : echo "$?"
+bash :
+minishell :
+notes :
+
+test : echo '$?'
+bash :
+minishell :
+notes :
+
+test : echo "$?str"
+bash :
+minishell :
+notes :
+
+test : echo $?$?
+bash :
+minishell :
+notes :
+
+test : echo str$?str
+bash :
+minishell :
+notes :
+
+test : echo $ ?str
+bash :
+minishell :
+notes :
+
+test : echo "$?"$?
+bash :
+minishell :
+notes :
+
+**Repeat with "$USER" and "$INVALID" ^


### PR DESCRIPTION
Fixed the function and tested it to work with any string, any whitespaces and quotes.
It leaves exactly one space between each token, except if the whitespaces are quoted.
